### PR TITLE
Implement comment toggling

### DIFF
--- a/src/flaskapp/static/js/index.js
+++ b/src/flaskapp/static/js/index.js
@@ -105,6 +105,15 @@ async function main() {
       theme: "material",
     });
 
+    codemirror.setOption('extraKeys', {
+      'Ctrl-/': function(cm) {
+        cm.toggleComment();
+      },
+      'Cmd-/': function(cm) {
+        cm.toggleComment();
+      },
+    });
+
     // 04. bind the document with the codemirror.
     // 04-1. codemirror to document(local).
     codemirror.on('beforeChange', (cm, change) => {

--- a/src/flaskapp/templates/index.html
+++ b/src/flaskapp/templates/index.html
@@ -17,6 +17,7 @@
     <link rel="stylesheet" href="/static/css/index.css"/>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/codemirror.js"></script>
+    <script src="https://codemirror.net/addon/comment/comment.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/mode/python/python.js"></script>
   </head>
 <body>


### PR DESCRIPTION
closes #39 

* Comment toggling 이제 가능합니다. 윈도우는 Ctrl + /, 맥은 Cmd + /로 가능합니다.