### PR TITLE
Add metadata, sync language across users

### DIFF
--- a/src/flaskapp/static/css/index.css
+++ b/src/flaskapp/static/css/index.css
@@ -210,3 +210,9 @@ html.light .dynamic-height .tab-content textarea{
     background-color: #fff;
     color: #000;
 }
+
+.scrollable-menu {
+    height: auto;
+    max-height: 200px;
+    overflow-x: hidden;
+}

--- a/src/flaskapp/static/js/config.js
+++ b/src/flaskapp/static/js/config.js
@@ -1,9 +1,9 @@
 const defaultConfig = {
-  lang: 'Python3',
-  tabSize: 4,
-  fontSize: 14,
+    lang: 'Python3',
+    tabSize: 4,
+    fontSize: 14,
 };
 
 const config = {
-  ...defaultConfig,
+    ...defaultConfig,
 };

--- a/src/flaskapp/static/js/config.js
+++ b/src/flaskapp/static/js/config.js
@@ -1,0 +1,9 @@
+const defaultConfig = {
+  lang: 'Python3',
+  tabSize: 4,
+  fontSize: 14,
+};
+
+const config = {
+  ...defaultConfig,
+};

--- a/src/flaskapp/static/js/index.js
+++ b/src/flaskapp/static/js/index.js
@@ -9,11 +9,11 @@ const peersHolder = document.getElementById('peers-holder');
 const selectionMap = new Map();
 
 function update_root(fieldName, value) {
-  doc.update((root) => {
-    const field = root[fieldName];
-    const text = field.getValue()
-    field.edit(0, text.length, value);
-  }, `Overwrite ${fieldName}`);
+    doc.update((root) => {
+        const field = root[fieldName];
+        const text = field.getValue()
+        field.edit(0, text.length, value);
+    }, `Overwrite ${fieldName}`);
 }
 
 function displayPeers(peers, clientID) {
@@ -85,12 +85,12 @@ function displayRemoteSelection(cm, change) {
 async function main() {
     try {
         // 01. create client with RPCAddr(envoy) then activate it.
-        const client = yorkie.createClient(API_URL);
+        client = yorkie.createClient(API_URL);
         client.subscribe(network.statusListener(statusHolder));
         await client.activate();
 
         // 02. create a document then attach it into the client.
-        const doc = yorkie.createDocument(collection, documentName);
+        doc = yorkie.createDocument(collection, documentName);
         await client.attach(doc);
         doc.update((root) => {
             for (const field of ['content', 'lang', 'title', 'desc']) {
@@ -230,7 +230,15 @@ async function main() {
 
                         const mode = lang_name(lang,'mode');
                         const button = $('#btnLanguageGroupDrop');
+                        const dropdown_items = button.siblings().find('.dropdown-item');
+
                         button.text(lang);
+                        dropdown_items.removeClass("active");
+                        for (e of dropdown_items) {
+                            if (e.textContent === lang) {
+                                e.classList.add('active');
+                            }
+                        }
                         await get_mime_js(lang);
                         codemirror.setOption('mode', mode);
                     }

--- a/src/flaskapp/static/js/index.js
+++ b/src/flaskapp/static/js/index.js
@@ -116,7 +116,11 @@ async function main() {
                     case 'lang':
                         elem = $('#btnLanguageGroupDrop');
                         elem.text(value);
-                        elem.parent().find(`.dropdown-menu .dropdown-item:contains("${value}")`).addClass('active');
+                        for (e of elem.parent().find(`.dropdown-menu .dropdown-item`)) {
+                            if (e.textContent === value) {
+                                e.classList.add('active');
+                            }
+                        }
                         break;
                 }
             }

--- a/src/flaskapp/static/js/index.js
+++ b/src/flaskapp/static/js/index.js
@@ -92,6 +92,13 @@ async function main() {
         // 02. create a document then attach it into the client.
         doc = yorkie.createDocument(collection, documentName);
         await client.attach(doc);
+
+        client.subscribe((event) => {
+            if (event.name === 'documents-watching-peer-changed') {
+                displayPeers(event.value[doc.getKey().toIDString()], client.getID());
+            }
+        });
+
         doc.update((root) => {
             for (const field of ['content', 'lang', 'title', 'desc']) {
                 if (!root[field]) {
@@ -140,12 +147,6 @@ async function main() {
             indentWithTabs: true,
         });
         $('.CodeMirror').css('font-size', parseInt(config['fontSize']));
-
-        client.subscribe((event) => {
-            if (event.name === 'documents-watching-peer-changed') {
-                displayPeers(event.value[doc.getKey().toIDString()], client.getID());
-            }
-        });
 
         codemirror.setOption('extraKeys', {
             'Ctrl-/': function(cm) {
@@ -217,7 +218,6 @@ async function main() {
 
         const langField = doc.getRootObject().lang;
         langField.onChanges(async (changes) => {
-            console.log("langField changed");
             for (const change of changes) {
                 if (change.type === 'content') {
                     const actor = change.actor;

--- a/src/flaskapp/static/js/index_generate_dynamic_html.js
+++ b/src/flaskapp/static/js/index_generate_dynamic_html.js
@@ -30,6 +30,6 @@ $(_=>{
         2);
     generate_dropdown_items("btnLanguageGroupDrop",
         Object.keys(lang_names),
-        "Python");
+        initialLang);
     
 });

--- a/src/flaskapp/static/js/index_generate_dynamic_html.js
+++ b/src/flaskapp/static/js/index_generate_dynamic_html.js
@@ -2,7 +2,7 @@
 generate_dropdown_items = function(id,item_list,def){
     var dropdown = $("#"+id);
     var group = document.createElement("div");
-    group.className = "dropdown-menu";
+    group.className = "dropdown-menu scrollable-menu";
     group.setAttribute("aria-labelledby",id);
 
     dropdown.parent().append(group);

--- a/src/flaskapp/static/js/index_generate_dynamic_html.js
+++ b/src/flaskapp/static/js/index_generate_dynamic_html.js
@@ -27,9 +27,9 @@ $(_=>{
         14);
     generate_dropdown_items("btnTabSizeGroupDrop",
         [2,4],
-        2);
+        4);
     generate_dropdown_items("btnLanguageGroupDrop",
         Object.keys(lang_names),
-        initialLang);
+    );
     
 });

--- a/src/flaskapp/static/js/index_register_element_callback.js
+++ b/src/flaskapp/static/js/index_register_element_callback.js
@@ -7,7 +7,7 @@ $(function () {
         var dropLabel = $('#'+id);
         $(this).addClass('active');
         $(this).siblings().removeClass('active');
-        dropLabel.text(dropLabel.data('desc')+': '+$(this).text()+' ');
+        dropLabel.text($(this).text());
     });
 
     $('#btnFontSizeGroupDrop').parent().find('.dropdown-menu .dropdown-item').on('click', function() {
@@ -44,6 +44,7 @@ $(function () {
 
         await get_mime_js(lang);
         cm.setOption('mode', mode);              
+        update_root('lang', lang);
     });
 
     $('#executeScript').on('click',async function(){

--- a/src/flaskapp/static/js/index_register_element_callback.js
+++ b/src/flaskapp/static/js/index_register_element_callback.js
@@ -7,7 +7,10 @@ $(function () {
         var dropLabel = $('#'+id);
         $(this).addClass('active');
         $(this).siblings().removeClass('active');
-        dropLabel.text($(this).text());
+
+        const desc = dropLabel.data('desc');
+        const value = desc ? `${desc}: ${$(this).text()}` : $(this).text();
+        dropLabel.text(value);
     });
 
     $('#btnFontSizeGroupDrop').parent().find('.dropdown-menu .dropdown-item').on('click', function() {

--- a/src/flaskapp/static/js/lang_name.js
+++ b/src/flaskapp/static/js/lang_name.js
@@ -66,9 +66,7 @@ init_lang_name = function(){
 init_lang_name();
 
 const cdn_mode_root = `https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/mode`;
-const initialLang = 'Python';
-let language = undefined;
-const imported = new Set( lang_name(initialLang, "mime") );
+const imported = new Set();
 
 async function get_mime_js(lang_type){
     const mime = lang_name(lang_type,'mime');

--- a/src/flaskapp/static/js/lang_name.js
+++ b/src/flaskapp/static/js/lang_name.js
@@ -65,8 +65,10 @@ init_lang_name = function(){
 
 init_lang_name();
 
-const cdn_mode_root = `https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/mode`
-const imported = new Set( lang_name("Python","mime") );
+const cdn_mode_root = `https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/mode`;
+const initialLang = 'Python';
+let language = undefined;
+const imported = new Set( lang_name(initialLang, "mime") );
 
 async function get_mime_js(lang_type){
     const mime = lang_name(lang_type,'mime');

--- a/src/flaskapp/templates/index.html
+++ b/src/flaskapp/templates/index.html
@@ -57,7 +57,6 @@
       <div class="tab-pane active" id="tabFile">
         <div class="btn-group btn-group-sm mr-2" role="group">
           <button id="btnLanguageGroupDrop" type="button" class="btn btn-secondary dropdown-toggle" data-desc="Language" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Language: Python
           </button>
         </div>
         <textarea id="script-input" placeholder="standard input:"></textarea>

--- a/src/flaskapp/templates/index.html
+++ b/src/flaskapp/templates/index.html
@@ -56,7 +56,7 @@
     <div class='tab-content bg-dark dis_none'>
       <div class="tab-pane active" id="tabFile">
         <div class="btn-group btn-group-sm mr-2" role="group">
-          <button id="btnLanguageGroupDrop" type="button" class="btn btn-secondary dropdown-toggle" data-desc="Language" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <button id="btnLanguageGroupDrop" type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           </button>
         </div>
         <textarea id="script-input" placeholder="standard input:"></textarea>
@@ -79,7 +79,7 @@
           
           <div class="btn-group btn-group-sm mr-2" role="group">
             <button id="btnTabSizeGroupDrop" type="button" class="btn btn-secondary dropdown-toggle" data-desc="Tab" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-              Tab: 2
+              Tab: 4
             </button>
           </div>
           <div class="btn-group btn-group-sm mr-2" role="group">
@@ -118,6 +118,7 @@
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
 
   <!-- Custom JavaScript -->
+  <script src="static/js/config.js"></script>
   <script src="static/js/runner.js"></script>
   <script src="static/js/yorkie.js"></script>
   <script src="static/js/util.js"></script>


### PR DESCRIPTION
closes #42 

## 큰 그림
* Metadata에 lang, title, desc를 추가했습니다
* Language를 유저들간에 항상 싱크합니다. 예를 들어 한 유저가 언어를 C++로 바꿀 경우 나머지 모든 유저들의 뷰도 C++로 바뀌게 됩니다.
* Language가 metadata로 트래킹이 되기 때문에 이제 페이지를 새로고침하거나 새로운 창에서 같은 도큐먼트를 열 경우 마지막으로 세팅해놓은 언어로 파일이 열리게 됩니다.
* 드롭다운 메뉴들이 스크롤이 가능하도록 바꿨습니다.

## 디테일
* `doc` 오브젝트가 언어 설정 때문에 `main` 함수 밖에서도 쓰여야 해서 글로벌 변수로 만들어버렸습니다..ㅠㅠ
* 언어 설정에 "Language: " 부분을 뺐습니다.
* `initialLang` 변수와 `language` 변수를 도입해 `initialLang = 'Python'`으로 하고, 실제로 언어 설정에 사용하는 변수는 `language`가 되도록 했습니다.