### PR TITLE
Load codemirror faster

### DIFF
--- a/src/flaskapp/static/js/index.js
+++ b/src/flaskapp/static/js/index.js
@@ -117,6 +117,20 @@ $(document).ready(function(){
 
 async function main() {
     try {
+        // 00. Create codemirror, but set it as read only until setup is complete.
+        const codemirror = CodeMirror.fromTextArea(placeholder, {
+            lineNumbers: true,
+            lineWrapping: true,
+            indentUnit: parseInt(config['tabSize']),
+            tabSize: parseInt(config['tabSize']),
+            theme: "material",
+            extraKeys: {"Alt-F": "findPersistent"},
+            indentWithTabs: true,
+            autoCloseBrackets: true,
+            readOnly: true,
+        });
+        $('.CodeMirror').css('font-size', parseInt(config['fontSize']));
+
         // 01. create client with RPCAddr(envoy) then activate it.
         client = yorkie.createClient(API_URL);
         client.subscribe(network.statusListener(statusHolder));
@@ -168,20 +182,9 @@ async function main() {
         await get_mime_js(config['lang']);
         await client.sync();
 
-        // 03. create an instance of codemirror.
-        const codemirror = CodeMirror.fromTextArea(placeholder, {
-            lineNumbers: true,
-            lineWrapping: true,
-            mode: lang_name(config['lang'], 'mode'),
-            indentUnit: parseInt(config['tabSize']),
-            tabSize: parseInt(config['tabSize']),
-            theme: "material",
-            extraKeys: {"Alt-F": "findPersistent"},
-            indentWithTabs: true,
-            autoCloseBrackets: true
-        });
-        $('.CodeMirror').css('font-size', parseInt(config['fontSize']));
-
+        // 03. Make codemirror usable
+        codemirror.setOption('readOnly', false);
+        codemirror.setOption('mode', lang_name(config['lang'], 'mode'));
         codemirror.setOption('extraKeys', {
             'Ctrl-/': function(cm) {
                 cm.toggleComment();

--- a/src/flaskapp/templates/index.html
+++ b/src/flaskapp/templates/index.html
@@ -15,24 +15,6 @@
     <link rel="stylesheet" href="/static/css/index.css"/>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/codemirror.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/comment/comment.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/dialog/dialog.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/search/searchcursor.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/search/search.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/scroll/annotatescrollbar.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/search/matchesonscrollbar.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/search/jump-to-line.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/keymap/sublime.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/keymap/vim.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/keymap/emacs.js"></script>
-
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/hint/show-hint.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/hint/anyword-hint.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/hint/javascript-hint.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/edit/matchbrackets.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/edit/closebrackets.min.js"></script>
-  
-    <script src="https://developers.kakao.com/sdk/js/kakao.min.js"></script>
   </head>
 <body>
   <nav class="navbar navbar-expand-sm navbar-dark bg-dark fixed-height">
@@ -59,7 +41,7 @@
   </div>
   <div class='dynamic-height'>
     <div class='container-fluid vertical-container'>
-      <textarea id="placeholder" cols="30" rows="10"><pre><code></code></pre></textarea>
+      <textarea id="placeholder" cols="30" rows="10"></textarea>
       <textarea id="console" readonly > </textarea>
     </div>
     <div class='tab-content bg-dark dis_none'>
@@ -315,13 +297,31 @@
   <script src="static/js/lang_name.js"></script>
   <script src="static/js/index_generate_dynamic_html.js"></script>
   <script src="static/js/index_register_element_callback.js"></script>
-  <script src="/static/js/login.js"></script>
   <script>
     const API_URL = '{{ API_URL }}';
     const collection = '{{ document_key[0] }}';
     const documentName = '{{ document_key[1] }}';
     main();
   </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/comment/comment.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/dialog/dialog.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/search/searchcursor.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/search/search.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/scroll/annotatescrollbar.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/search/matchesonscrollbar.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/search/jump-to-line.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/keymap/sublime.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/keymap/vim.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/keymap/emacs.js"></script>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/hint/show-hint.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/hint/anyword-hint.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/hint/javascript-hint.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/edit/matchbrackets.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/edit/closebrackets.min.js"></script>
+
+  <script src="https://developers.kakao.com/sdk/js/kakao.min.js"></script>
+  <script src="/static/js/login.js"></script>
   </body>
 </html>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/dialog/dialog.css">

--- a/src/flaskapp/templates/index.html
+++ b/src/flaskapp/templates/index.html
@@ -9,11 +9,6 @@
     <link rel="icon" href="/static/favicon.svg">
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/codemirror.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/dialog/dialog.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/search/matchesonscrollbar.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/theme/material.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/theme/solarized.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/hint/show-hint.css">
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
     <link rel="stylesheet" href="https://pro.fontawesome.com/releases/v5.10.0/css/all.css" integrity="sha384-AYmEC3Yw5cVb3ZcuHtOA93w35dYTsvhLPVnYs9eStHfGJvOvKxVfELGroGkvsg+p" crossorigin="anonymous"/>
 
@@ -331,3 +326,8 @@
   </script>
   </body>
 </html>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/dialog/dialog.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/search/matchesonscrollbar.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/theme/material.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/theme/solarized.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/hint/show-hint.css">

--- a/src/flaskapp/templates/index.html
+++ b/src/flaskapp/templates/index.html
@@ -16,8 +16,6 @@
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/codemirror.js"></script>
     <script src="https://codemirror.net/addon/comment/comment.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/mode/python/python.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/mode/clike/clike.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/dialog/dialog.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/search/searchcursor.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/search/search.js"></script>

--- a/src/flaskapp/templates/index.html
+++ b/src/flaskapp/templates/index.html
@@ -15,7 +15,7 @@
     <link rel="stylesheet" href="/static/css/index.css"/>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/codemirror.js"></script>
-    <script src="https://codemirror.net/addon/comment/comment.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/comment/comment.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/dialog/dialog.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/search/searchcursor.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.48.4/addon/search/search.js"></script>


### PR DESCRIPTION
closes #55 

* 초기에 필요없는 js 파일 삭제 (`python.js`, `clike.js`)
* 나중에 로드되어도 상관없는 css 및 js 파일들의 경우 문서 하단으로 옮김
* `main()` 함수에서 codemirror 생성 시점을 맨 앞으로 옮김
    * 초기에 `readOnly: true`로 생성해 yorkie가 셋업되지 않은 시점에는 유저가 실질적인 edit은 하지 못하도록 막고, 셋업이 끝난 시점에 codemirror를 수정 가능하도록 구현